### PR TITLE
mark-devkit: Bump kde-apps/kde-meta-23.08.2

### DIFF
--- a/kde-apps/kde-meta/kde-meta-23.08.2.ebuild
+++ b/kde-apps/kde-meta/kde-meta-23.08.2.ebuild
@@ -1,0 +1,16 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Merge this to pull in all KDE Plasma and Applications packages"
+HOMEPAGE="https://kde.org/"
+
+LICENSE="metapackage"
+SLOT="5"
+KEYWORDS="*"
+IUSE=""
+
+RDEPEND="
+	>=kde-apps/kde-apps-meta-${PV}:${SLOT}
+	kde-plasma/plasma-meta:5
+"


### PR DESCRIPTION
Automatic bump of package kde-apps/kde-meta-23.08.2 for branch mark-iii by mark-bot