### PR TITLE
mark-devkit: Bump kde-apps/kdebase-meta-23.08.2

### DIFF
--- a/kde-apps/kdebase-meta/kdebase-meta-23.08.2.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-23.08.2.ebuild
@@ -1,0 +1,16 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Transitional package to pull in plasma-meta plus basic applications"
+HOMEPAGE="https://kde.org/"
+
+LICENSE="metapackage"
+SLOT="5"
+KEYWORDS="*"
+IUSE=""
+
+RDEPEND="
+	>=kde-apps/kdecore-meta-${PV}:${SLOT}
+	kde-plasma/plasma-meta
+"


### PR DESCRIPTION
Automatic bump of package kde-apps/kdebase-meta-23.08.2 for branch mark-iii by mark-bot