### PR TITLE
mark-devkit: Bump kde-apps/kdegraphics-meta-23.08.2

### DIFF
--- a/kde-apps/kdegraphics-meta/kdegraphics-meta-23.08.2.ebuild
+++ b/kde-apps/kdegraphics-meta/kdegraphics-meta-23.08.2.ebuild
@@ -1,0 +1,29 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="kdegraphics - merge this to pull in all kdegraphics-derived packages"
+HOMEPAGE="https://apps.kde.org/graphics"
+
+LICENSE="metapackage"
+SLOT="5"
+KEYWORDS="*"
+IUSE="scanner"
+
+RDEPEND="
+	>=kde-apps/gwenview-${PV}:${SLOT}
+	>=kde-apps/kamera-${PV}:${SLOT}
+	>=kde-apps/kcolorchooser-${PV}:${SLOT}
+	>=kde-apps/kdegraphics-mobipocket-${PV}:${SLOT}
+	>=kde-apps/kipi-plugins-${PV}:${SLOT}
+	>=kde-apps/kolourpaint-${PV}:${SLOT}
+	>=kde-apps/kruler-${PV}:${SLOT}
+	>=kde-apps/libkdcraw-${PV}:${SLOT}
+	>=kde-apps/libkexiv2-${PV}:${SLOT}
+	>=kde-apps/libkipi-${PV}:${SLOT}
+	>=kde-apps/okular-${PV}:${SLOT}
+	>=kde-apps/spectacle-${PV}:${SLOT}
+	>=kde-apps/svgpart-${PV}:${SLOT}
+	>=kde-apps/thumbnailers-${PV}:${SLOT}
+	scanner? ( >=kde-apps/libksane-${PV}:${SLOT} )
+"


### PR DESCRIPTION
Automatic bump of package kde-apps/kdegraphics-meta-23.08.2 for branch mark-iii by mark-bot