### PR TITLE
mark-devkit: Bump kde-apps/kdeutils-meta-23.08.2

### DIFF
--- a/kde-apps/kdeutils-meta/kdeutils-meta-23.08.2.ebuild
+++ b/kde-apps/kdeutils-meta/kdeutils-meta-23.08.2.ebuild
@@ -1,0 +1,45 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="kdeutils - merge this to pull in all kdeutils-derived packages"
+HOMEPAGE="https://apps.kde.org/utilities https://utils.kde.org"
+
+LICENSE="metapackage"
+SLOT="5"
+KEYWORDS="*"
+IUSE="7zip cups floppy gpg lrz rar +webengine"
+
+RDEPEND="
+	>=app-cdr/dolphin-plugins-mountiso-${PV}:${SLOT}
+	>=kde-apps/ark-${PV}:${SLOT}
+	>=kde-apps/filelight-${PV}:${SLOT}
+	>=kde-apps/kate-${PV}:${SLOT}
+	>=kde-apps/kbackup-${PV}:${SLOT}
+	>=kde-apps/kcalc-${PV}:${SLOT}
+	>=kde-apps/kcharselect-${PV}:${SLOT}
+	>=kde-apps/kdebugsettings-${PV}:${SLOT}
+	>=kde-apps/kdf-${PV}:${SLOT}
+	>=kde-apps/kteatime-${PV}:${SLOT}
+	>=kde-apps/ktimer-${PV}:${SLOT}
+	>=kde-apps/kwalletmanager-${PV}:${SLOT}
+	>=kde-apps/sweeper-${PV}:${SLOT}
+	>=kde-apps/yakuake-${PV}:${SLOT}
+	>=kde-misc/markdownpart-${PV}:${SLOT}
+	>=sys-block/partitionmanager-${PV}:${SLOT}
+	>=sys-libs/kpmcore-${PV}:${SLOT}
+	cups? ( >=kde-apps/print-manager-${PV}:${SLOT} )
+	floppy? ( >=kde-apps/kfloppy-23.04.3:${SLOT} )
+	gpg? ( >=kde-apps/kgpg-${PV}:${SLOT} )
+	webengine? ( >=kde-apps/kimagemapeditor-${PV}:${SLOT} )
+"
+# Optional runtime deps: kde-apps/ark
+RDEPEND="${RDEPEND}
+	7zip? ( app-arch/p7zip )
+	lrz? ( app-arch/lrzip )
+	rar? ( || (
+		app-arch/rar
+		app-arch/unrar
+		app-arch/unar
+	) )
+"


### PR DESCRIPTION
Automatic bump of package kde-apps/kdeutils-meta-23.08.2 for branch mark-iii by mark-bot