### PR TITLE
mark-devkit: Bump kde-apps/kdemultimedia-meta-23.08.2

### DIFF
--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-23.08.2.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-23.08.2.ebuild
@@ -1,0 +1,28 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="kdemultimedia - merge this to pull in all kdemultimedia-derived packages"
+HOMEPAGE="https://apps.kde.org/multimedia https://multimedia.kde.org/"
+
+LICENSE="metapackage"
+SLOT="5"
+KEYWORDS="*"
+IUSE="+cdrom +ffmpeg gstreamer"
+
+RDEPEND="
+	>=kde-apps/dragon-${PV}:${SLOT}
+	>=kde-apps/juk-${PV}:${SLOT}
+	>=kde-apps/kdenlive-${PV}:${SLOT}
+	>=kde-apps/kmix-${PV}:${SLOT}
+	>=kde-apps/kwave-${PV}:${SLOT}
+	>=media-sound/elisa-${PV}:${SLOT}
+	cdrom? (
+		>=kde-apps/audiocd-kio-${PV}:${SLOT}
+		>=kde-apps/k3b-${PV}:${SLOT}
+		>=kde-apps/libkcddb-${PV}:${SLOT}
+		>=kde-apps/libkcompactdisc-${PV}:${SLOT}
+	)
+	ffmpeg? ( >=kde-apps/ffmpegthumbs-${PV}:${SLOT} )
+	gstreamer? ( >=kde-apps/kamoso-${PV}:${SLOT} )
+"


### PR DESCRIPTION
Automatic bump of package kde-apps/kdemultimedia-meta-23.08.2 for branch mark-iii by mark-bot