### PR TITLE
mark-devkit: Bump kde-frameworks/prison-5.111.0-r1

### DIFF
--- a/kde-frameworks/prison/prison-5.111.0-r1.ebuild
+++ b/kde-frameworks/prison/prison-5.111.0-r1.ebuild
@@ -30,7 +30,4 @@ src_configure() {
 	)
 
 	kde5_src_configure
-	# Zxing using exceptions. So we need to drop
-	# -fno-exceptions flag.
-	sed -i -e 's|-fno-exceptions||g' ${WORKDIR}/${P}_build/build.ninja || die
 }


### PR DESCRIPTION
Automatic bump of package kde-frameworks/prison-5.111.0-r1 for branch mark-iii by mark-bot