### PR TITLE
mark-devkit: Bump kde-plasma/plymouth-kcm-5.27.9-r1

### DIFF
--- a/kde-plasma/plymouth-kcm/plymouth-kcm-5.27.9-r1.ebuild
+++ b/kde-plasma/plymouth-kcm/plymouth-kcm-5.27.9-r1.ebuild
@@ -35,3 +35,4 @@ RDEPEND="${DEPEND}
 	$(add_plasma_dep kde-cli-tools)
 "
 
+DOCS=( CONTRIBUTORS )


### PR DESCRIPTION
Automatic bump of package kde-plasma/plymouth-kcm-5.27.9-r1 for branch mark-iii by mark-bot