### PR TITLE
mark-devkit: Bump kde-frameworks/frameworkintegration-5.111.0-r1

### DIFF
--- a/kde-frameworks/frameworkintegration/frameworkintegration-5.111.0-r1.ebuild
+++ b/kde-frameworks/frameworkintegration/frameworkintegration-5.111.0-r1.ebuild
@@ -22,6 +22,7 @@ RDEPEND="
 	$(add_frameworks_dep knewstuff)
 	$(add_frameworks_dep knotifications)
 	appstream? (
+		app-admin/packagekit-qt
 		dev-libs/appstream[qt5]
 	)
 	X? (


### PR DESCRIPTION
Automatic bump of package kde-frameworks/frameworkintegration-5.111.0-r1 for branch mark-iii by mark-bot