### PR TITLE
mark-devkit: Bump x11-libs/libfm-extra-1.3.1-r1

### DIFF
--- a/x11-libs/libfm-extra/libfm-extra-1.3.1-r1.ebuild
+++ b/x11-libs/libfm-extra/libfm-extra-1.3.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/lxde/libfm/archive/${PV}.tar.gz -> ${MY_P}.tar.gz"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~mips ~ppc ~x86 ~amd64-linux ~x86-linux"
 LICENSE="GPL-2"
 SLOT="0/5.2.1" #copy ABI_VERSION because it seems upstream change it randomly
-IUSE="prefix"
+IUSE=""
 
 RDEPEND=">=dev-libs/glib-2.18:2"
 DEPEND="${RDEPEND}
@@ -71,6 +71,16 @@ src_install() {
 	# symlink to it.
 	if [[ -h ${D}/usr/include/${MY_PN} || -d ${D}/usr/include/${MY_PN} ]]; then
 		rm -r "${D}"/usr/include/${MY_PN}
+	fi
+}
+
+pkg_preinst() {
+	# Resolve the symlink mess. Bug #439570
+	[[ -d "${ROOT}"/usr/include/${MY_PN} ]] && \
+		rm -rf "${ROOT}"/usr/include/${MY_PN}
+	if [[ -d "${D}"/usr/include/${MY_PN}-1.0 ]]; then
+		cd "${D}"/usr/include
+		ln -s --force ${MY_PN}-1.0 ${MY_PN}
 	fi
 }
 


### PR DESCRIPTION
Automatic bump of package x11-libs/libfm-extra-1.3.1-r1 for branch mark-unstable by mark-bot