### PR TITLE
mark-devkit: [mark-31] Bump x11-libs/libfm-1.3.1-r1

### DIFF
--- a/x11-libs/libfm/libfm-1.3.1-r1.ebuild
+++ b/x11-libs/libfm/libfm-1.3.1-r1.ebuild
@@ -38,7 +38,7 @@ DEPEND="${COMMON_DEPEND}
 	>=dev-util/intltool-0.40
 	virtual/pkgconfig
 	sys-devel/gettext
-	dev-util/glib-utils"
+"
 
 S="${WORKDIR}"/${MY_P}
 


### PR DESCRIPTION
Automatic bump of package x11-libs/libfm-1.3.1-r1 for branch mark-31 by mark-bot