### PR TITLE
mark-devkit: [mark-31] Bump kde-apps/kig-25.12.1-r1

### DIFF
--- a/kde-apps/kig/kig-25.12.1-r1.ebuild
+++ b/kde-apps/kig/kig-25.12.1-r1.ebuild
@@ -2,7 +2,8 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+PYTHON_COMPAT=( python3+ )
+inherit kde6 python-single-r1 xdg
 
 DESCRIPTION="KDE Interactive Geometry tool"
 HOMEPAGE="https://apps.kde.org/kig/"


### PR DESCRIPTION
Automatic bump of package kde-apps/kig-25.12.1-r1 for branch mark-31 by mark-bot