### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kparts-6.22.0-r1

### DIFF
--- a/kde-frameworks/kparts/kparts-6.22.0-r1.ebuild
+++ b/kde-frameworks/kparts/kparts-6.22.0-r1.ebuild
@@ -2,14 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing elaborate user-interface components"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kparts-6.22.0.tar.xz -> kparts-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
@@ -22,7 +23,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kparts-6.22.0-r1 for branch mark-31 by mark-bot