### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/networkmanager-qt-6.22.0-r1

### DIFF
--- a/kde-frameworks/networkmanager-qt/networkmanager-qt-6.22.0-r1.ebuild
+++ b/kde-frameworks/networkmanager-qt/networkmanager-qt-6.22.0-r1.ebuild
@@ -2,21 +2,20 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Qt wrapper for NetworkManager API"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/networkmanager-qt-6.22.0.tar.xz -> networkmanager-qt-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="teamd"
-RDEPEND="dev-qt/qtbase:6
-	>=net-misc/networkmanager-1.4.0-r1[teamd?]
+RDEPEND="virtual/kde-seed
+	net-misc/networkmanager[teamd?]
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/networkmanager-qt-6.22.0-r1 for branch mark-31 by mark-bot