### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/attica-6.22.0-r1

### DIFF
--- a/kde-frameworks/attica/attica-6.22.0-r1.ebuild
+++ b/kde-frameworks/attica/attica-6.22.0-r1.ebuild
@@ -2,23 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing access to Open Collaboration Services"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/attica-6.22.0.tar.xz -> attica-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # requires network access, bug #661230
-	  providertest
-)
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/attica-6.22.0-r1 for branch mark-31 by mark-bot