### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kapidox-6.22.0-r1

### DIFF
--- a/kde-frameworks/kapidox/kapidox-6.22.0-r1.ebuild
+++ b/kde-frameworks/kapidox/kapidox-6.22.0-r1.ebuild
@@ -3,20 +3,26 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3+ )
-inherit kde6 distutils-r1
+DISTUTILS_SINGLE_IMPL=1
+DISTUTILS_USE_PEP517=setuptools
+inherit distutils-r1
 
 DESCRIPTION="Framework for building KDE API documentation in a standard format and style"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kapidox-6.22.0.tar.xz -> kapidox-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="app-text/doxygen
+RDEPEND="virtual/kde-seed
+	app-doc/doxygen
 	$(python_gen_cond_dep '
-	    dev-python/jinja2[${PYTHON_USEDEP}]
+	    dev-python/jinja[${PYTHON_USEDEP}]
 	    dev-python/pyyaml[${PYTHON_USEDEP}]
 	')
 	media-gfx/graphviz[python,${PYTHON_SINGLE_USEDEP}]
 	
+"
+DEPEND="${RDEPEND}
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kapidox-6.22.0-r1 for branch mark-31 by mark-bot