### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/extra-cmake-modules-6.22.0-r1

### DIFF
--- a/kde-frameworks/extra-cmake-modules/extra-cmake-modules-6.22.0-r1.ebuild
+++ b/kde-frameworks/extra-cmake-modules/extra-cmake-modules-6.22.0-r1.ebuild
@@ -3,70 +3,43 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3+ )
-inherit cmake kde6 python-any-r1
+inherit cmake python-any-r1
 
 DESCRIPTION="Extra modules and scripts for CMake"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/extra-cmake-modules-6.22.0.tar.xz -> extra-cmake-modules-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="*"
+IUSE="doc"
 BDEPEND="doc? (
 	    ${PYTHON_DEPS}
 	    $(python_gen_any_dep 'dev-python/sphinx[${PYTHON_USEDEP}]')
-	    dev-qt/qttools:0[assistant]
-	)
-	test? (
-	    dev-qt/qtbase:0
-	    dev-qt/qttools:0[linguist]
+	    dev-qt/qttools:6[assistant]
 	)
 	
 "
 RDEPEND="app-arch/libarchive[bzip2]
+	!kde-frameworks/extra-cmake-modules:5
 	
 "
-DEPEND="test? (
-	    dev-qt/qtbase:0[gui]
-	    dev-qt/qtdeclarative:0
-	)
-	
+DEPEND="${RDEPEND}
 "
-python_check_deps() {
-	  python_has_version "dev-python/sphinx[${PYTHON_USEDEP}]"
-}
-
 pkg_setup() {
 	  use doc && python-any-r1_pkg_setup
 }
-
 src_prepare() {
 	  cmake_src_prepare
 }
-
 src_configure() {
 	  local mycmakeargs=(
 	      -DDOC_INSTALL_DIR=/usr/share/doc/"${PF}"
 	      -DBUILD_QTHELP_DOCS=$(usex doc)
 	      -DBUILD_HTML_DOCS=$(usex doc)
 	      -DBUILD_MAN_DOCS=$(usex doc)
-	      -DBUILD_TESTING=$(usex test)
+	      -DBUILD_TESTING=OFF
 	  )
-	  if use test; then
-	      mycmakeargs+=( -DQT_MAJOR_VERSION=6 ) # bug 938316
-	  fi
-	   cmake_src_configure
-}
-
-src_test() {
-	  local CMAKE_SKIP_TESTS=(
-	      # passes, but then breaks src_install
-	      ECMToolchainAndroidTest
-	      # broken, bug #627806
-	      ECMPoQmToolsTest
-	      # can not possibly succeed in releases, bug #764953
-	      KDEFetchTranslations
-	  )
-	  # possible race condition with multiple jobs, bug #701854
-	  cmake_src_test -j1
+	  cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/extra-cmake-modules-6.22.0-r1 for branch mark-31 by mark-bot