### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kdav-6.22.0-r1

### DIFF
--- a/kde-frameworks/kdav/kdav-6.22.0-r1.ebuild
+++ b/kde-frameworks/kdav/kdav-6.22.0-r1.ebuild
@@ -2,30 +2,21 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="DAV protocol implemention with KJobs"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kdav-6.22.0.tar.xz -> kdav-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kio:6
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # bug 616808: requires D-Bus
-	  kdav-davitemfetchjob
-	  # bug 653602: mimetypes unsupported
-	  kdav-davitemslistjob
-	  # bug 765061
-	  kdav-davcollectionsmultifetchjobtest
-)
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kdav-6.22.0-r1 for branch mark-31 by mark-bot