### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kholidays-6.22.0-r1

### DIFF
--- a/kde-frameworks/kholidays/kholidays-6.22.0-r1.ebuild
+++ b/kde-frameworks/kholidays/kholidays-6.22.0-r1.ebuild
@@ -2,28 +2,21 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Library to determine holidays and other special events for a geographical region"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kholidays-6.22.0.tar.xz -> kholidays-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[declarative]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_test() {
-	  # bug 624214
-	  mkdir -p "${HOME}/.local/share/kf6/libkholidays" || die
-	  cp -r "${S}/holidays/plan2" "${HOME}/.local/share/kf6/libkholidays/" || die
-	  kde6_src_test
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kholidays-6.22.0-r1 for branch mark-31 by mark-bot