### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/ktexttemplate-6.22.0-r1

### DIFF
--- a/kde-frameworks/ktexttemplate/ktexttemplate-6.22.0-r1.ebuild
+++ b/kde-frameworks/ktexttemplate/ktexttemplate-6.22.0-r1.ebuild
@@ -2,22 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Library to allow separating the structure of documents from data they contain"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/ktexttemplate-6.22.0.tar.xz -> ktexttemplate-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND="test? ( dev-qt/qttools:6[linguist] )
-	
-"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/ktexttemplate-6.22.0-r1 for branch mark-31 by mark-bot