### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kcrash-6.22.0-r1

### DIFF
--- a/kde-frameworks/kcrash/kcrash-6.22.0-r1.ebuild
+++ b/kde-frameworks/kcrash/kcrash-6.22.0-r1.ebuild
@@ -2,36 +2,32 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for intercepting and handling application crashes"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kcrash-6.22.0.tar.xz -> kcrash-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="X"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcoreaddons:6
 	X? ( x11-libs/libX11 )
 	
 "
 DEPEND="${RDEPEND}
 	X? ( x11-base/xorg-proto )
-	test? ( dev-qt/qtbase:6 )
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DWITH_X11=$(usex X)
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DWITH_X11=$(usex X)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kcrash-6.22.0-r1 for branch mark-31 by mark-bot