### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/knotifyconfig-6.22.0-r1

### DIFF
--- a/kde-frameworks/knotifyconfig/knotifyconfig-6.22.0-r1.ebuild
+++ b/kde-frameworks/knotifyconfig/knotifyconfig-6.22.0-r1.ebuild
@@ -2,15 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for configuring desktop notifications"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/knotifyconfig-6.22.0.tar.xz -> knotifyconfig-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtmultimedia:6
+RDEPEND="virtual/kde-seed[gui,multimedia]
 	kde-frameworks/kcompletion:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/ki18n:6
@@ -18,13 +18,12 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 src_configure() {
-	  local mycmakeargs=(
-	      -DCMAKE_DISABLE_FIND_PACKAGE_Canberra=ON
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DCMAKE_DISABLE_FIND_PACKAGE_Canberra=ON
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/knotifyconfig-6.22.0-r1 for branch mark-31 by mark-bot