### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kplotting-6.22.0-r1

### DIFF
--- a/kde-frameworks/kplotting/kplotting-6.22.0-r1.ebuild
+++ b/kde-frameworks/kplotting/kplotting-6.22.0-r1.ebuild
@@ -2,18 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing easy data-plotting functions"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kplotting-6.22.0.tar.xz -> kplotting-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kplotting-6.22.0-r1 for branch mark-31 by mark-bot