### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kstatusnotifieritem-6.22.0-r1

### DIFF
--- a/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-6.22.0-r1.ebuild
+++ b/kde-frameworks/kstatusnotifieritem/kstatusnotifieritem-6.22.0-r1.ebuild
@@ -2,35 +2,31 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Implementation of Status Notifier Items"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kstatusnotifieritem-6.22.0.tar.xz -> kstatusnotifieritem-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="X"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui,X?]
 	kde-frameworks/kwindowsystem:6[X?]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DWITHOUT_X11=$(usex !X)
-	      -DBUILD_PYTHON_BINDINGS=OFF
-	      -DCMAKE_DISABLE_FIND_PACKAGE_{Python3,PySide6,Shiboken6}=ON
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DWITHOUT_X11=$(usex !X)
+	  -DBUILD_PYTHON_BINDINGS=OFF
+	  -DCMAKE_DISABLE_FIND_PACKAGE_{Python3,PySide6,Shiboken6}=ON
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kstatusnotifieritem-6.22.0-r1 for branch mark-31 by mark-bot