### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/prison-6.22.0-r1

### DIFF
--- a/kde-frameworks/prison/prison-6.22.0-r1.ebuild
+++ b/kde-frameworks/prison/prison-6.22.0-r1.ebuild
@@ -2,33 +2,28 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="QRCode and data matrix barcode library"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/prison-6.22.0.tar.xz -> prison-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="qml"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtmultimedia:6
+RDEPEND="virtual/kde-seed[gui,multimedia]
 	media-gfx/qrencode:=
 	media-libs/libdmtx
 	qml? ( dev-qt/qtdeclarative:6 )
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DWITH_QUICK=$(usex qml)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DWITH_QUICK=$(usex qml)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/prison-6.22.0-r1 for branch mark-31 by mark-bot