### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kcolorscheme-6.22.0-r1

### DIFF
--- a/kde-frameworks/kcolorscheme/kcolorscheme-6.22.0-r1.ebuild
+++ b/kde-frameworks/kcolorscheme/kcolorscheme-6.22.0-r1.ebuild
@@ -2,22 +2,21 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for downloading and sharing additional application data"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kcolorscheme-6.22.0.tar.xz -> kcolorscheme-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	kde-frameworks/kconfig:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kguiaddons:6
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kcolorscheme-6.22.0-r1 for branch mark-31 by mark-bot