### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kglobalaccel-6.22.0-r1

### DIFF
--- a/kde-frameworks/kglobalaccel/kglobalaccel-6.22.0-r1.ebuild
+++ b/kde-frameworks/kglobalaccel/kglobalaccel-6.22.0-r1.ebuild
@@ -2,33 +2,28 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework to handle global shortcuts"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kglobalaccel-6.22.0.tar.xz -> kglobalaccel-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="X"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
-	X? ( dev-qt/qtbase:6=[X] )
+RDEPEND="virtual/kde-seed[gui,X?]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DWITH_X11=$(usex X)
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DWITH_X11=$(usex X)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kglobalaccel-6.22.0-r1 for branch mark-31 by mark-bot