### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/ktextwidgets-6.22.0-r1

### DIFF
--- a/kde-frameworks/ktextwidgets/ktextwidgets-6.22.0-r1.ebuild
+++ b/kde-frameworks/ktextwidgets/ktextwidgets-6.22.0-r1.ebuild
@@ -2,15 +2,16 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing an assortment of widgets for displaying and editing text"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/ktextwidgets-6.22.0.tar.xz -> ktextwidgets-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="speech"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcompletion:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
@@ -21,17 +22,12 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DWITH_TEXT_TO_SPEECH=$(usex speech)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DWITH_TEXT_TO_SPEECH=$(usex speech)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/ktextwidgets-6.22.0-r1 for branch mark-31 by mark-bot