### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kcalendarcore-6.22.0-r1

### DIFF
--- a/kde-frameworks/kcalendarcore/kcalendarcore-6.22.0-r1.ebuild
+++ b/kde-frameworks/kcalendarcore/kcalendarcore-6.22.0-r1.ebuild
@@ -2,20 +2,19 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Library for interfacing with calendars"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kcalendarcore-6.22.0.tar.xz -> kcalendarcore-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND=">=dev-libs/libical-3.0.5:=
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
+	>=dev-libs/libical-3.0.5:=
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kcalendarcore-6.22.0-r1 for branch mark-31 by mark-bot