### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/threadweaver-6.22.0-r1

### DIFF
--- a/kde-frameworks/threadweaver/threadweaver-6.22.0-r1.ebuild
+++ b/kde-frameworks/threadweaver/threadweaver-6.22.0-r1.ebuild
@@ -2,16 +2,22 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for managing threads using job and queue-based interfaces"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/threadweaver-6.22.0.tar.xz -> threadweaver-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
+RDEPEND="virtual/kde-seed
+	
+"
+DEPEND="${RDEPEND}
+"
 src_prepare() {
 	  cmake_comment_add_subdirectory benchmarks
-	  kde6_src_prepare
+	  cmake_src_prepare
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/threadweaver-6.22.0-r1 for branch mark-31 by mark-bot