### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kdnssd-6.22.0-r1

### DIFF
--- a/kde-frameworks/kdnssd/kdnssd-6.22.0-r1.ebuild
+++ b/kde-frameworks/kdnssd/kdnssd-6.22.0-r1.ebuild
@@ -2,37 +2,32 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for network service discovery using Zeroconf"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kdnssd-6.22.0.tar.xz -> kdnssd-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="zeroconf"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed
 	zeroconf? (
-	    dev-qt/qtbase:6
 	    net-dns/avahi[mdnsresponder-compat]
 	)
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package zeroconf Avahi)
-	  )
-	  use zeroconf || mycmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_DNSSD=ON )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package zeroconf Avahi)
+	)
+	use zeroconf || mycmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_DNSSD=ON )
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kdnssd-6.22.0-r1 for branch mark-31 by mark-bot