### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/qqc2-desktop-style-6.22.0-r1

### DIFF
--- a/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-6.22.0-r1.ebuild
+++ b/kde-frameworks/qqc2-desktop-style/qqc2-desktop-style-6.22.0-r1.ebuild
@@ -2,25 +2,24 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Style for QtQuickControls2 that uses QWidget's QStyle for painting"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/qqc2-desktop-style-6.22.0.tar.xz -> qqc2-desktop-style-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	kde-frameworks/kcolorscheme:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kiconthemes:6
 	kde-frameworks/kirigami:6
 	kde-frameworks/sonnet:6
+	kde-frameworks/kcoreaddons:6
 	
 "
 DEPEND="${RDEPEND}
-	kde-frameworks/kcoreaddons:6
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/qqc2-desktop-style-6.22.0-r1 for branch mark-31 by mark-bot