### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kded-6.22.0-r1

### DIFF
--- a/kde-frameworks/kded/kded-6.22.0-r1.ebuild
+++ b/kde-frameworks/kded/kded-6.22.0-r1.ebuild
@@ -2,18 +2,19 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Central daemon of KDE workspaces"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kded-6.22.0.tar.xz -> kded-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="+man"
 BDEPEND="man? ( kde-frameworks/kdoctools:6 )
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kconfig:6[dbus]
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -22,17 +23,12 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package man KF6DocTools)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package man KF6DocTools)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kded-6.22.0-r1 for branch mark-31 by mark-bot