### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kconfig-6.22.0-r1

### DIFF
--- a/kde-frameworks/kconfig/kconfig-6.22.0-r1.ebuild
+++ b/kde-frameworks/kconfig/kconfig-6.22.0-r1.ebuild
@@ -2,36 +2,31 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for reading and writing configuration"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kconfig-6.22.0.tar.xz -> kconfig-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="dbus qml"
-REQUIRED_USE="test? ( qml )"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
+	dbus? ( sys-apps/dbus )
 	qml? ( dev-qt/qtdeclarative:6 )
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DUSE_DBUS=$(usex dbus)
-	      -DKCONFIG_USE_QML=$(usex qml)
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DUSE_DBUS=$(usex dbus)
+	  -DKCONFIG_USE_QML=$(usex qml)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kconfig-6.22.0-r1 for branch mark-31 by mark-bot