### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kconfigwidgets-6.22.0-r1

### DIFF
--- a/kde-frameworks/kconfigwidgets/kconfigwidgets-6.22.0-r1.ebuild
+++ b/kde-frameworks/kconfigwidgets/kconfigwidgets-6.22.0-r1.ebuild
@@ -2,14 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing an assortment of configuration-related widgets"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kconfigwidgets-6.22.0.tar.xz -> kconfigwidgets-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcodecs:6
 	kde-frameworks/kcolorscheme:6
 	kde-frameworks/kconfig:6
@@ -20,15 +21,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	test? ( kde-frameworks/kconfig:6[dbus] )
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # bugs: 864250
-	  kstandardactiontest
-	  # bug 926497
-	  klanguagenametest
-)
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kconfigwidgets-6.22.0-r1 for branch mark-31 by mark-bot