### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kxmlgui-6.22.0-r1

### DIFF
--- a/kde-frameworks/kxmlgui/kxmlgui-6.22.0-r1.ebuild
+++ b/kde-frameworks/kxmlgui/kxmlgui-6.22.0-r1.ebuild
@@ -2,14 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for managing menu and toolbar actions in an abstract way"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kxmlgui-6.22.0.tar.xz -> kxmlgui-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kconfigwidgets:6
 	kde-frameworks/kcoreaddons:6
@@ -22,26 +23,13 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # bug 668198: files are missing; whatever.
-	  ktoolbar_unittest
-	  # bug 650290
-	  kxmlgui_unittest
-	  # bug 808216
-	  ktooltiphelper_unittest
-)
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DBUILD_PYTHON_BINDINGS=OFF
-	      -DCMAKE_DISABLE_FIND_PACKAGE_{Python3,PySide6,Shiboken6}=ON
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DBUILD_PYTHON_BINDINGS=OFF
+	  -DCMAKE_DISABLE_FIND_PACKAGE_{Python3,PySide6,Shiboken6}=ON
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kxmlgui-6.22.0-r1 for branch mark-31 by mark-bot