### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kitemmodels-6.22.0-r1

### DIFF
--- a/kde-frameworks/kitemmodels/kitemmodels-6.22.0-r1.ebuild
+++ b/kde-frameworks/kitemmodels/kitemmodels-6.22.0-r1.ebuild
@@ -2,23 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing data models to help with tasks such as sorting and filtering"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kitemmodels-6.22.0.tar.xz -> kitemmodels-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[declarative]
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
-src_test() {
-	  LC_NUMERIC="C" kde6_src_test # bug 708820
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kitemmodels-6.22.0-r1 for branch mark-31 by mark-bot