### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/solid-6.22.0-r1

### DIFF
--- a/kde-frameworks/solid/solid-6.22.0-r1.ebuild
+++ b/kde-frameworks/solid/solid-6.22.0-r1.ebuild
@@ -2,11 +2,12 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 optfeature
+inherit cmake
 
 DESCRIPTION="Provider for platform independent hardware discovery, abstraction and management"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/solid-6.22.0.tar.xz -> solid-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="ios"
@@ -15,37 +16,24 @@ BDEPEND="sys-devel/bison
 	dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	sys-apps/util-linux
 	sys-fs/udisks:2
 	virtual/libudev:=
 	ios? (
-	    app-pda/libimobiledevice:=
-	    app-pda/libplist:=
+	  app-pda/libimobiledevice:=
+	  app-pda/libplist:=
 	)
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package ios IMobileDevice)
-	      $(cmake_use_find_package ios PList)
-	  )
-	  kde6_src_configure
-}
-
-pkg_postinst() {
-	  if [[ -z "${REPLACING_VERSIONS}" ]]; then
-	      optfeature "media player devices support" app-misc/media-player-info
-	  fi
+	local mycmakeargs=(
+	  $(cmake_use_find_package ios IMobileDevice)
+	  $(cmake_use_find_package ios PList)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/solid-6.22.0-r1 for branch mark-31 by mark-bot