### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/syndication-6.22.0-r1

### DIFF
--- a/kde-frameworks/syndication/syndication-6.22.0-r1.ebuild
+++ b/kde-frameworks/syndication/syndication-6.22.0-r1.ebuild
@@ -2,20 +2,19 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Library for parsing RSS and Atom feeds"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/syndication-6.22.0.tar.xz -> syndication-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed
 	kde-frameworks/kcodecs:6
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/syndication-6.22.0-r1 for branch mark-31 by mark-bot