### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/syntax-highlighting-6.22.0-r1

### DIFF
--- a/kde-frameworks/syntax-highlighting/syntax-highlighting-6.22.0-r1.ebuild
+++ b/kde-frameworks/syntax-highlighting/syntax-highlighting-6.22.0-r1.ebuild
@@ -2,24 +2,23 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for syntax highlighting"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/syntax-highlighting-6.22.0.tar.xz -> syntax-highlighting-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 BDEPEND="dev-lang/perl
 	dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
+	dev-libs/xerces-c
 	
 "
 DEPEND="${RDEPEND}
-	dev-libs/xerces-c
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/syntax-highlighting-6.22.0-r1 for branch mark-31 by mark-bot