### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/bluez-qt-6.22.0-r1

### DIFF
--- a/kde-frameworks/bluez-qt/bluez-qt-6.22.0-r1.ebuild
+++ b/kde-frameworks/bluez-qt/bluez-qt-6.22.0-r1.ebuild
@@ -2,24 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Qt wrapper for Bluez 5 DBus API"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/bluez-qt-6.22.0.tar.xz -> bluez-qt-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[declarative]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_test() {
-	  # parallel tests fail, bug 609248
-	  kde6_src_test -j1
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/bluez-qt-6.22.0-r1 for branch mark-31 by mark-bot