### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kiconthemes-6.22.0-r1

### DIFF
--- a/kde-frameworks/kiconthemes/kiconthemes-6.22.0-r1.ebuild
+++ b/kde-frameworks/kiconthemes/kiconthemes-6.22.0-r1.ebuild
@@ -2,16 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for icon theming and configuration"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kiconthemes-6.22.0.tar.xz -> kiconthemes-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
-	dev-qt/qtsvg:6
+RDEPEND="virtual/kde-seed[gui,declarative,svg]
 	kde-frameworks/breeze-icons:6
 	kde-frameworks/karchive:6
 	kde-frameworks/kcolorscheme:6
@@ -21,7 +20,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kiconthemes-6.22.0-r1 for branch mark-31 by mark-bot