### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kservice-6.22.0-r1

### DIFF
--- a/kde-frameworks/kservice/kservice-6.22.0-r1.ebuild
+++ b/kde-frameworks/kservice/kservice-6.22.0-r1.ebuild
@@ -2,36 +2,31 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Advanced plugin and service introspection"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kservice-6.22.0.tar.xz -> kservice-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="+man"
 BDEPEND="man? ( kde-frameworks/kdoctools:6 )
 	
 "
-RDEPEND="dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package man KF6DocTools)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package man KF6DocTools)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kservice-6.22.0-r1 for branch mark-31 by mark-bot