### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/modemmanager-qt-6.22.0-r1

### DIFF
--- a/kde-frameworks/modemmanager-qt/modemmanager-qt-6.22.0-r1.ebuild
+++ b/kde-frameworks/modemmanager-qt/modemmanager-qt-6.22.0-r1.ebuild
@@ -2,19 +2,19 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Qt wrapper for ModemManager DBus API"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/modemmanager-qt-6.22.0.tar.xz -> modemmanager-qt-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed
 	>=net-misc/modemmanager-0.7.991
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/modemmanager-qt-6.22.0-r1 for branch mark-31 by mark-bot