### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/ki18n-6.22.0-r1

### DIFF
--- a/kde-frameworks/ki18n/ki18n-6.22.0-r1.ebuild
+++ b/kde-frameworks/ki18n/ki18n-6.22.0-r1.ebuild
@@ -3,46 +3,35 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3+ )
-inherit kde6 python-single-r1
+inherit cmake python-single-r1
 
 DESCRIPTION="Framework based on Gettext for internationalizing user interface text"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/ki18n-6.22.0.tar.xz -> ki18n-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RDEPEND="app-text/iso-codes
+BDEPEND="${PYTHON_DEPS}
+	sys-devel/gettext
+	virtual/libintl
+	
+"
+RDEPEND="virtual/kde-seed[declarative]
+	app-text/iso-codes
 	
 "
 DEPEND="${RDEPEND}
-	${PYTHON_DEPS}
-	dev-qt/qtbase:6
-	dev-qt/qtdeclarative:6
-	sys-devel/gettext
-	virtual/libintl
-	test? ( dev-qt/qtbase:6 )
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # bug 876496
-	  kcatalogtest
-	  # requires LANG fr_CH. bugs 823816
-	  kcountrytest
-	  kcountrysubdivisiontest
-	  # flaky, bug 948895
-	  ki18n-klocalizedstringtest
-)
-
 src_prepare() {
-	  kde6_src_prepare
+	cmake_src_prepare
 }
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DPython3_EXECUTABLE="${PYTHON}"
-	      -DBUILD_WITH_QML=TRUE
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DPython3_EXECUTABLE="${PYTHON}"
+	  -DBUILD_WITH_QML=TRUE
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/ki18n-6.22.0-r1 for branch mark-31 by mark-bot