### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kcmutils-6.22.0-r1

### DIFF
--- a/kde-frameworks/kcmutils/kcmutils-6.22.0-r1.ebuild
+++ b/kde-frameworks/kcmutils/kcmutils-6.22.0-r1.ebuild
@@ -2,15 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework to work with KDE System Settings modules"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kcmutils-6.22.0.tar.xz -> kcmutils-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kconfigwidgets:6
 	kde-frameworks/kcoreaddons:6
@@ -23,7 +23,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kcmutils-6.22.0-r1 for branch mark-31 by mark-bot