### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kirigami-6.22.0-r1

### DIFF
--- a/kde-frameworks/kirigami/kirigami-6.22.0-r1.ebuild
+++ b/kde-frameworks/kirigami/kirigami-6.22.0-r1.ebuild
@@ -2,43 +2,35 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 toolchain-funcs
+inherit cmake toolchain-funcs
 
 DESCRIPTION="Lightweight user interface framework for mobile and convergent applications"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kirigami-6.22.0.tar.xz -> kirigami-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="examples openmp"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="examples? (
-	    !kde-frameworks/kirigami:5[examples(-)]
+RDEPEND="virtual/kde-seed[gui,declarative,svg]
+	examples? (
 	    dev-qt/qt5compat:6[qml]
 	)
 	
 "
 DEPEND="${RDEPEND}
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
-	dev-qt/qtsvg:6
-	
 "
 pkg_pretend() {
 	  [[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 }
-
-pkg_setup() {
-	  [[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DBUILD_EXAMPLES=$(usex examples)
-	      $(cmake_use_find_package openmp OpenMP)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DBUILD_EXAMPLES=$(usex examples)
+	  $(cmake_use_find_package openmp OpenMP)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kirigami-6.22.0-r1 for branch mark-31 by mark-bot