### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/krunner-6.22.0-r1

### DIFF
--- a/kde-frameworks/krunner/krunner-6.22.0-r1.ebuild
+++ b/kde-frameworks/krunner/krunner-6.22.0-r1.ebuild
@@ -2,34 +2,24 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for providing different actions given a string query"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/krunner-6.22.0.tar.xz -> krunner-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+IUSE="wayland"
+RDEPEND="virtual/kde-seed[gui,wayland?]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kitemmodels:6
-	kde-frameworks/kwindowsystem:6[wayland]
+	kde-frameworks/kwindowsystem:6[wayland?]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-CMAKE_SKIP_TESTS=(
-	  # requires virtual dbus, otherwise hangs; bugs #630672
-	  dbusrunnertest
-	  # bug 789351
-	  runnermanagersinglerunnermodetest
-	  # bug 838502
-	  runnermanagertest
-	  # bug 926502, needs dbus
-	  threadingtest
-)
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/krunner-6.22.0-r1 for branch mark-31 by mark-bot