### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/ksvg-6.22.0-r1

### DIFF
--- a/kde-frameworks/ksvg/ksvg-6.22.0-r1.ebuild
+++ b/kde-frameworks/ksvg/ksvg-6.22.0-r1.ebuild
@@ -2,16 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Components for handling SVGs"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/ksvg-6.22.0.tar.xz -> ksvg-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
-	dev-qt/qtsvg:6
+RDEPEND="virtual/kde-seed[gui,declarative,svg]
 	kde-frameworks/karchive:6
 	kde-frameworks/kcolorscheme:6
 	kde-frameworks/kconfig:6
@@ -21,7 +20,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/ksvg-6.22.0-r1 for branch mark-31 by mark-bot