### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kcompletion-6.22.0-r1

### DIFF
--- a/kde-frameworks/kcompletion/kcompletion-6.22.0-r1.ebuild
+++ b/kde-frameworks/kcompletion/kcompletion-6.22.0-r1.ebuild
@@ -2,17 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for common completion tasks such as filename or URL completion"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kcompletion-6.22.0.tar.xz -> kcompletion-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcodecs:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
@@ -20,7 +21,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kcompletion-6.22.0-r1 for branch mark-31 by mark-bot