### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kdesu-6.22.0-r1

### DIFF
--- a/kde-frameworks/kdesu/kdesu-6.22.0-r1.ebuild
+++ b/kde-frameworks/kdesu/kdesu-6.22.0-r1.ebuild
@@ -2,15 +2,17 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework to handle super user actions"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kdesu-6.22.0.tar.xz -> kdesu-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="X"
-RDEPEND="kde-frameworks/kconfig:6
+RDEPEND="virtual/kde-seed
+	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kpty:6
@@ -21,15 +23,11 @@ DEPEND="${RDEPEND}
 	X? ( x11-base/xorg-proto )
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package X X11)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package X X11)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kdesu-6.22.0-r1 for branch mark-31 by mark-bot