### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kpty-6.22.0-r1

### DIFF
--- a/kde-frameworks/kpty/kpty-6.22.0-r1.ebuild
+++ b/kde-frameworks/kpty/kpty-6.22.0-r1.ebuild
@@ -2,30 +2,27 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework for pseudo terminal devices and running child processes"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kpty-6.22.0.tar.xz -> kpty-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="kde-frameworks/kcoreaddons:6
+RDEPEND="virtual/kde-seed
+	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	sys-libs/libutempter
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DUTEMPTER_EXECUTABLE="${EPREFIX}/usr/sbin/utempter"
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DUTEMPTER_EXECUTABLE="${EPREFIX}/usr/sbin/utempter"
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kpty-6.22.0-r1 for branch mark-31 by mark-bot