### PR TITLE
mark-devkit: [mark-31] Bump kde-frameworks/kwindowsystem-6.22.0-r1

### DIFF
--- a/kde-frameworks/kwindowsystem/kwindowsystem-6.22.0-r1.ebuild
+++ b/kde-frameworks/kwindowsystem/kwindowsystem-6.22.0-r1.ebuild
@@ -2,49 +2,43 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Framework providing access to properties and features of the window manager"
 HOMEPAGE="https://invent.kde.org/frameworks/"
 SRC_URI="https://download.kde.org/stable/frameworks/6.22/kwindowsystem-6.22.0.tar.xz -> kwindowsystem-6.22.0.tar.xz"
+LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
 IUSE="wayland X"
 BDEPEND="dev-qt/qttools:6[linguist]
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
-	wayland? ( dev-qt/qtbase:6[wayland] )
+RDEPEND="virtual/kde-seed[gui,declarative,wayland?,X?]
 	X? (
-	    dev-qt/qtbase:6[gui,X]
-	    x11-base/xorg-proto
-	    x11-libs/libX11
-	    x11-libs/libXfixes
-	    x11-libs/libxcb
-	    x11-libs/xcb-util-keysyms
+	  x11-libs/libX11
+	  x11-libs/libXfixes
+	  x11-libs/libxcb
+	  x11-libs/xcb-util-keysyms
 	)
-	wayland? ( || ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 ) )
 	
 "
 DEPEND="${RDEPEND}
-	test? ( dev-qt/qtbase:6 )
+	X? (
+	  x11-base/xorg-proto
+	)
 	wayland? (
 	    dev-libs/plasma-wayland-protocols
 	    >=dev-libs/wayland-protocols-1.21
 	)
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DKWINDOWSYSTEM_WAYLAND=$(usex wayland)
-	      -DKWINDOWSYSTEM_X11=$(usex X)
-	  )
-	   kde6_src_configure
+	local mycmakeargs=(
+	  -DKWINDOWSYSTEM_WAYLAND=$(usex wayland)
+	  -DKWINDOWSYSTEM_X11=$(usex X)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-frameworks/kwindowsystem-6.22.0-r1 for branch mark-31 by mark-bot