### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/ksystemstats-6.5.5-r1

### DIFF
--- a/kde-plasma/ksystemstats/ksystemstats-6.5.5-r1.ebuild
+++ b/kde-plasma/ksystemstats/ksystemstats-6.5.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Plugin based system monitoring daemon"
 HOMEPAGE="https://invent.kde.org/plasma/"
@@ -10,8 +10,7 @@ SRC_URI="https://download.kde.org/stable/plasma/6.5.5/ksystemstats-6.5.5.tar.xz 
 SLOT="6"
 KEYWORDS="*"
 IUSE="networkmanager"
-RDEPEND="dev-qt/qtbase:6
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[declarative]
 	kde-frameworks/kauth:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -27,17 +26,12 @@ RDEPEND="dev-qt/qtbase:6
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package networkmanager KF6NetworkManagerQt)
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package networkmanager KF6NetworkManagerQt)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/ksystemstats-6.5.5-r1 for branch mark-31 by mark-bot