### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kdecoration-6.5.5-r1

### DIFF
--- a/kde-plasma/kdecoration/kdecoration-6.5.5-r1.ebuild
+++ b/kde-plasma/kdecoration/kdecoration-6.5.5-r1.ebuild
@@ -2,23 +2,18 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Plugin based library to create window decorations"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kdecoration-6.5.5.tar.xz -> kdecoration-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/ki18n:6
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kdecoration-6.5.5-r1 for branch mark-31 by mark-bot