### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/libkscreen-6.5.5-r1

### DIFF
--- a/kde-plasma/libkscreen/libkscreen-6.5.5-r1.ebuild
+++ b/kde-plasma/libkscreen/libkscreen-6.5.5-r1.ebuild
@@ -2,31 +2,27 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Plasma screen management library"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/libkscreen-6.5.5.tar.xz -> libkscreen-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND=">=dev-libs/plasma-wayland-protocols-1.18.0
+IUSE="wayland"
+BDEPEND="kde-frameworks/kconfig:6
 	dev-qt/qttools:6[linguist]
-	dev-qt/qtbase:6[wayland]
-	dev-util/wayland-scanner
+	wayland? (
+	  dev-libs/plasma-wayland-protocols
+	  dev-util/wayland-scanner
+	)
 	
 "
-RDEPEND="dev-libs/wayland
-	dev-qt/qtbase:6[gui,wayland]
-	kde-frameworks/kconfig:6
+RDEPEND="virtual/kde-seed[gui,wayland?]
 	x11-libs/libxcb:=
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/libkscreen-6.5.5-r1 for branch mark-31 by mark-bot