### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/milou-6.5.5-r1

### DIFF
--- a/kde-plasma/milou/milou-6.5.5-r1.ebuild
+++ b/kde-plasma/milou/milou-6.5.5-r1.ebuild
@@ -2,15 +2,14 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Dedicated search application built on top of Baloo"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/milou-6.5.5.tar.xz -> milou-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kservice:6
@@ -19,11 +18,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/milou-6.5.5-r1 for branch mark-31 by mark-bot