### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/plasma-thunderbolt-6.5.5-r1

### DIFF
--- a/kde-plasma/plasma-thunderbolt/plasma-thunderbolt-6.5.5-r1.ebuild
+++ b/kde-plasma/plasma-thunderbolt/plasma-thunderbolt-6.5.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Plasma integration for controlling Thunderbolt devices"
 HOMEPAGE="https://invent.kde.org/plasma/plasma-thunderbolt"
@@ -10,28 +10,20 @@ SRC_URI="https://download.kde.org/stable/plasma/6.5.5/plasma-thunderbolt-6.5.5.t
 LICENSE="|| ( GPL-2 GPL-3+ )"
 SLOT="6"
 KEYWORDS="~amd64 ~loong ~riscv ~x86"
-RESTRICT="test"
 BDEPEND="kde-frameworks/kcmutils:6
 	
 "
-RDEPEND="kde-frameworks/kirigami:6
-	sys-apps/bolt
-	
-"
-DEPEND="${RDEPEND}
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
-	kde-frameworks/kcmutils:6
+RDEPEND="virtual/kde-seed[gui,declarative]
+	kde-frameworks/kirigami:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kdbusaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/knotifications:6
 	kde-frameworks/kservice:6
+	sys-apps/bolt
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
+DEPEND="${RDEPEND}
+"
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/plasma-thunderbolt-6.5.5-r1 for branch mark-31 by mark-bot