### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/layer-shell-qt-6.5.5-r1

### DIFF
--- a/kde-plasma/layer-shell-qt/layer-shell-qt-6.5.5-r1.ebuild
+++ b/kde-plasma/layer-shell-qt/layer-shell-qt-6.5.5-r1.ebuild
@@ -2,27 +2,24 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Qt component to allow applications to make use of Wayland wl-layer-shell protocol"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/layer-shell-qt-6.5.5.tar.xz -> layer-shell-qt-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND=">=dev-libs/wayland-protocols-1.16
-	dev-util/wayland-scanner
+IUSE="wayland"
+BDEPEND="wayland? (
+	  >=dev-libs/wayland-protocols-1.16
+	  dev-util/wayland-scanner
+	)
 	
 "
-RDEPEND="dev-qt/qtbase:6[gui,wayland]
-	dev-qt/qtwayland:6
+RDEPEND="virtual/kde-seed[gui,wayland?]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/layer-shell-qt-6.5.5-r1 for branch mark-31 by mark-bot