### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kactivitymanagerd-6.5.5-r1

### DIFF
--- a/kde-plasma/kactivitymanagerd/kactivitymanagerd-6.5.5-r1.ebuild
+++ b/kde-plasma/kactivitymanagerd/kactivitymanagerd-6.5.5-r1.ebuild
@@ -2,14 +2,15 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="System service to manage user's activities, track the usage patterns etc."
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kactivitymanagerd-6.5.5.tar.xz -> kactivitymanagerd-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui,sql,sqlite]
+RDEPEND="virtual/kde-seed[gui,sql]
+	dev-qt/qtbase:6[sqlite]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -24,11 +25,6 @@ RDEPEND="dev-qt/qtbase:6[gui,sql,sqlite]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kactivitymanagerd-6.5.5-r1 for branch mark-31 by mark-bot