### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/powerdevil-6.5.5-r1

### DIFF
--- a/kde-plasma/powerdevil/powerdevil-6.5.5-r1.ebuild
+++ b/kde-plasma/powerdevil/powerdevil-6.5.5-r1.ebuild
@@ -2,27 +2,21 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 fcaps xdg
+inherit cmake fcaps xdg
 
 DESCRIPTION="Power management for KDE Plasma Shell"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/powerdevil-6.5.5.tar.xz -> powerdevil-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-IUSE="brightness-control"
-RDEPEND="!<kde-plasma/plasma-workspace-6.1.90:*
-	dev-qt/qtdeclarative:6
+IUSE="wayland brightness-control"
+RDEPEND="virtual/kde-seed[gui,declarative,wayland?]
+	dev-libs/qcoro[dbus]
 	|| (
 	    sys-power/power-profiles-daemon
 	    sys-power/tlp
 	)
 	>=sys-power/upower-0.9.23
-	
-"
-DEPEND="${RDEPEND}
-	dev-libs/qcoro[dbus]
-	dev-libs/wayland
-	dev-qt/qtbase:6[gui,wayland]
 	kde-frameworks/kauth:6[policykit]
 	kde-frameworks/kcmutils:6
 	kde-frameworks/kconfig:6
@@ -51,15 +45,16 @@ DEPEND="${RDEPEND}
 	brightness-control? ( app-misc/ddcutil:= )
 	
 "
+DEPEND="${RDEPEND}
+"
 src_prepare() {
-	  kde6_src_prepare
+	cmake_src_prepare
 }
-
 src_configure() {
-	  local mycmakeargs=(
-	      $(cmake_use_find_package brightness-control DDCUtil)
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  $(cmake_use_find_package brightness-control DDCUtil)
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/powerdevil-6.5.5-r1 for branch mark-31 by mark-bot