### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kmenuedit-6.5.5-r1

### DIFF
--- a/kde-plasma/kmenuedit/kmenuedit-6.5.5-r1.ebuild
+++ b/kde-plasma/kmenuedit/kmenuedit-6.5.5-r1.ebuild
@@ -2,14 +2,14 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="KDE menu editor"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kmenuedit-6.5.5.tar.xz -> kmenuedit-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/ki18n:6
 	kde-frameworks/kiconthemes:6
 	kde-frameworks/kio:6
@@ -20,11 +20,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kmenuedit-6.5.5-r1 for branch mark-31 by mark-bot