### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/bluedevil-6.5.5-r1

### DIFF
--- a/kde-plasma/bluedevil/bluedevil-6.5.5-r1.ebuild
+++ b/kde-plasma/bluedevil/bluedevil-6.5.5-r1.ebuild
@@ -2,27 +2,20 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake xdg
 
 DESCRIPTION="Bluetooth stack for KDE Plasma"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/bluedevil-6.5.5.tar.xz -> bluedevil-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND="kde-frameworks/kcmutils:6
-	
-"
-RDEPEND="kde-frameworks/kirigami:6
-	
-"
-DEPEND="${RDEPEND}
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
 	kde-frameworks/bluez-qt:6
 	kde-frameworks/kcmutils:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kdbusaddons:6
+	kde-frameworks/kirigami:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kio:6
 	kde-frameworks/kjobwidgets:6
@@ -34,8 +27,10 @@ DEPEND="${RDEPEND}
 	kde-plasma/libplasma:6
 	
 "
+DEPEND="${RDEPEND}
+"
 src_prepare() {
-	  kde6_src_prepare
+	cmake_src_prepare
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/bluedevil-6.5.5-r1 for branch mark-31 by mark-bot