### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/plasma-activities-stats-6.5.5-r1

### DIFF
--- a/kde-plasma/plasma-activities-stats/plasma-activities-stats-6.5.5-r1.ebuild
+++ b/kde-plasma/plasma-activities-stats/plasma-activities-stats-6.5.5-r1.ebuild
@@ -2,24 +2,19 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Library for accessing the usage data collected by the activities system"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/plasma-activities-stats-6.5.5.tar.xz -> plasma-activities-stats-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[sql]
+RDEPEND="virtual/kde-seed[sql]
 	kde-frameworks/kconfig:6
 	kde-plasma/plasma-activities:6
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/plasma-activities-stats-6.5.5-r1 for branch mark-31 by mark-bot