### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/plasma-systemmonitor-6.5.5-r1

### DIFF
--- a/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-6.5.5-r1.ebuild
+++ b/kde-plasma/plasma-systemmonitor/plasma-systemmonitor-6.5.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Monitor system sensors, process information and other system resources"
 HOMEPAGE="https://apps.kde.org/plasma-systemmonitor/"
@@ -10,16 +10,11 @@ SRC_URI="https://download.kde.org/stable/plasma/6.5.5/plasma-systemmonitor-6.5.5
 LICENSE="|| ( GPL-3 GPL-2 )"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="kde-frameworks/kirigami:6
+RDEPEND="virtual/kde-seed[gui,declarative]
+	>=dev-libs/kirigami-addons-1.1.0:6
+	kde-frameworks/kirigami:6
 	kde-frameworks/kitemmodels:6
 	kde-frameworks/kquickcharts:6
-	kde-plasma/ksystemstats:6
-	
-"
-DEPEND="${RDEPEND}
-	>=dev-libs/kirigami-addons-1.1.0:6
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -33,12 +28,11 @@ DEPEND="${RDEPEND}
 	kde-frameworks/kpackage:6
 	kde-frameworks/kservice:6
 	kde-frameworks/kwindowsystem:6
+	kde-plasma/ksystemstats:6
 	kde-plasma/libksysguard:6
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
+DEPEND="${RDEPEND}
+"
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/plasma-systemmonitor-6.5.5-r1 for branch mark-31 by mark-bot