### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/breeze-grub-6.5.5-r1

### DIFF
--- a/kde-plasma/breeze-grub/breeze-grub-6.5.5-r1.ebuild
+++ b/kde-plasma/breeze-grub/breeze-grub-6.5.5-r1.ebuild
@@ -2,20 +2,21 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6
+inherit cmake
 
 DESCRIPTION="Breeze theme for GRUB"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/breeze-grub-6.5.5.tar.xz -> breeze-grub-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
+DEPEND="${RDEPEND}
+"
 src_prepare() { default; }
 src_configure() { :; }
 src_compile() { :; }
-
 src_install() {
-	  insinto /usr/share/grub/themes
-	  doins -r breeze
+	insinto /usr/share/grub/themes
+	doins -r breeze
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/breeze-grub-6.5.5-r1 for branch mark-31 by mark-bot