### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kwrited-6.5.5-r1

### DIFF
--- a/kde-plasma/kwrited/kwrited-6.5.5-r1.ebuild
+++ b/kde-plasma/kwrited/kwrited-6.5.5-r1.ebuild
@@ -2,14 +2,14 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="KDE Plasma daemon listening for wall and write messages"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kwrited-6.5.5.tar.xz -> kwrited-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kdbusaddons:6
 	kde-frameworks/ki18n:6
@@ -18,11 +18,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kwrited-6.5.5-r1 for branch mark-31 by mark-bot