### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/plasma-browser-integration-6.5.5-r1

### DIFF
--- a/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.5.5-r1.ebuild
+++ b/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.5.5-r1.ebuild
@@ -2,14 +2,14 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake xdg
 
 DESCRIPTION="Integrate Chrome/Firefox better into Plasma through browser extensions"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/plasma-browser-integration-6.5.5.tar.xz -> plasma-browser-integration-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -28,17 +28,15 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
 src_prepare() {
-	  kde6_src_prepare
+	cmake_src_prepare
 }
-
 src_configure() {
-	  local mycmakeargs=(
-	      -DMOZILLA_DIR="${EPREFIX}/usr/$(get_libdir)/mozilla"
-	  )
-	  kde6_src_configure
+	local mycmakeargs=(
+	  -DMOZILLA_DIR="${EPREFIX}/usr/$(get_libdir)/mozilla"
+	)
+	cmake_src_configure
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/plasma-browser-integration-6.5.5-r1 for branch mark-31 by mark-bot