### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/plasma-workspace-wallpapers-6.5.5-r1

### DIFF
--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-6.5.5-r1.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-6.5.5-r1.ebuild
@@ -10,13 +10,13 @@ SRC_URI="https://download.kde.org/stable/plasma/6.5.5/plasma-workspace-wallpaper
 LICENSE="GPL-2"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND="dev-qt/qtbase:6
-	kde-frameworks/extra-cmake-modules:0
+BDEPEND="kde-frameworks/extra-cmake-modules
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
+RDEPEND="virtual/kde-seed
+	
+"
+DEPEND="${RDEPEND}
+"
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/plasma-workspace-wallpapers-6.5.5-r1 for branch mark-31 by mark-bot