### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/xdg-desktop-portal-kde-6.5.5-r1

### DIFF
--- a/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-6.5.5-r1.ebuild
+++ b/kde-plasma/xdg-desktop-portal-kde/xdg-desktop-portal-kde-6.5.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Backend implementation for xdg-desktop-portal that is using Qt/KDE Frameworks"
 HOMEPAGE="https://invent.kde.org/plasma/"
@@ -10,25 +10,20 @@ SRC_URI="https://download.kde.org/stable/plasma/6.5.5/xdg-desktop-portal-kde-6.5
 LICENSE="LGPL-2+"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND="dev-qt/qtbase:6[wayland]
-	virtual/pkgconfig
-	|| ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )
+IUSE="wayland"
+BDEPEND="virtual/pkgconfig
+	wayland? (
+	  dev-libs/plasma-wayland-protocols
+	  dev-libs/wayland-protocols
+	)
 	
 "
-RDEPEND="kde-misc/kio-fuse:6
+RDEPEND="virtual/kde-seed[wayland?]
+	kde-misc/kio-fuse
 	sys-apps/xdg-desktop-portal
-	|| ( >=dev-qt/qtbase-6.10:6[wayland] <dev-qt/qtwayland-6.10:6 )
 	
 "
 DEPEND="${RDEPEND}
-	>=dev-libs/plasma-wayland-protocols-1.18.0
-	>=dev-libs/wayland-protocols-1.25
-	dev-qt/qtbase:6
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/xdg-desktop-portal-kde-6.5.5-r1 for branch mark-31 by mark-bot