### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/ksshaskpass-6.5.5-r1

### DIFF
--- a/kde-plasma/ksshaskpass/ksshaskpass-6.5.5-r1.ebuild
+++ b/kde-plasma/ksshaskpass/ksshaskpass-6.5.5-r1.ebuild
@@ -2,27 +2,22 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Implementation of ssh-askpass with KDE Wallet integration"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/ksshaskpass-6.5.5.tar.xz -> ksshaskpass-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="net-misc/openssh
-	
-"
-DEPEND="${RDEPEND}
-	dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
+	net-misc/openssh
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kwallet:6
 	kde-frameworks/kwidgetsaddons:6
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
+DEPEND="${RDEPEND}
+"
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/ksshaskpass-6.5.5-r1 for branch mark-31 by mark-bot