### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kwayland-integration-6.5.5-r1

### DIFF
--- a/kde-plasma/kwayland-integration/kwayland-integration-6.5.5-r1.ebuild
+++ b/kde-plasma/kwayland-integration/kwayland-integration-6.5.5-r1.ebuild
@@ -2,15 +2,14 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Provides integration plugins for various KDE frameworks for Wayland"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kwayland-integration-6.5.5.tar.xz -> kwayland-integration-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui,wayland]
-	dev-qt/qtwayland:6
+RDEPEND="virtual/kde-seed[gui,wayland]
 	kde-frameworks/kguiaddons:6[wayland]
 	kde-frameworks/kidletime:6[wayland]
 	kde-frameworks/knotifications:6
@@ -22,11 +21,6 @@ RDEPEND="dev-qt/qtbase:6[gui,wayland]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kwayland-integration-6.5.5-r1 for branch mark-31 by mark-bot