### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/wacomtablet-6.5.5-r1

### DIFF
--- a/kde-plasma/wacomtablet/wacomtablet-6.5.5-r1.ebuild
+++ b/kde-plasma/wacomtablet/wacomtablet-6.5.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake
 
 DESCRIPTION="Wacom system settings module that supports different button/pen layout profiles"
 HOMEPAGE="https://userbase.kde.org/Wacomtablet"
@@ -13,9 +13,8 @@ KEYWORDS="*"
 BDEPEND="sys-devel/gettext
 	
 "
-RDEPEND=">=dev-libs/libwacom-0.30:=
-	dev-qt/qtbase:6[gui]
-	dev-qt/qtdeclarative:6
+RDEPEND="virtual/kde-seed[gui,declarative]
+	>=dev-libs/libwacom-0.30:=
 	kde-frameworks/kcmutils:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kconfigwidgets:6
@@ -33,24 +32,12 @@ RDEPEND=">=dev-libs/libwacom-0.30:=
 	>=x11-drivers/xf86-input-wacom-0.20.0
 	x11-libs/libXi
 	x11-libs/libxcb
+	x11-libs/libX11
 	
 "
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto
-	x11-libs/libX11
 	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
-src_test() {
-	  # test needs DBus, bug 675548
-	  local myctestargs=(
-	      -E "(Test.KDED.DBusTabletService)"
-	  )
-	   kde6_src_test
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/wacomtablet-6.5.5-r1 for branch mark-31 by mark-bot