### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/flatpak-kcm-6.5.5-r1

### DIFF
--- a/kde-plasma/flatpak-kcm/flatpak-kcm-6.5.5-r1.ebuild
+++ b/kde-plasma/flatpak-kcm/flatpak-kcm-6.5.5-r1.ebuild
@@ -2,35 +2,30 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit kde6 xdg
+inherit cmake xdg
 
 DESCRIPTION="Flatpak Permissions Management KCM"
 HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/flatpak-kcm-6.5.5.tar.xz -> flatpak-kcm-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-BDEPEND="kde-frameworks/kcmutils:6
-	
-"
-RDEPEND="kde-frameworks/kirigami:6
-	
-"
-DEPEND="${RDEPEND}
-	dev-libs/glib:2
-	dev-qt/qtbase:6
+RDEPEND="virtual/kde-seed[gui,svg,declarative]
 	dev-qt/qtdeclarative:6[widgets]
-	dev-qt/qtsvg:6
+	dev-libs/glib:2
+	kde-frameworks/kirigami:6
 	kde-frameworks/kcmutils:6
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kdeclarative:6
 	kde-frameworks/ki18n:6
 	kde-frameworks/kitemmodels:6
-	>=sys-apps/flatpak-0.11.8
+	sys-apps/flatpak
 	
 "
+DEPEND="${RDEPEND}
+"
 src_prepare() {
-	  kde6_src_prepare
+	cmake_src_prepare
 }
 
 


### PR DESCRIPTION
Automatic bump of package kde-plasma/flatpak-kcm-6.5.5-r1 for branch mark-31 by mark-bot