### PR TITLE
mark-devkit: [mark-31] Bump kde-plasma/kglobalacceld-6.5.5-r1

### DIFF
--- a/kde-plasma/kglobalacceld/kglobalacceld-6.5.5-r1.ebuild
+++ b/kde-plasma/kglobalacceld/kglobalacceld-6.5.5-r1.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://invent.kde.org/plasma/"
 SRC_URI="https://download.kde.org/stable/plasma/6.5.5/kglobalacceld-6.5.5.tar.xz -> kglobalacceld-6.5.5.tar.xz"
 SLOT="6"
 KEYWORDS="*"
-RDEPEND="dev-qt/qtbase:6[gui]
+RDEPEND="virtual/kde-seed[gui]
 	kde-frameworks/kconfig:6
 	kde-frameworks/kcoreaddons:6
 	kde-frameworks/kcrash:6
@@ -23,11 +23,6 @@ RDEPEND="dev-qt/qtbase:6[gui]
 	
 "
 DEPEND="${RDEPEND}
-	
 "
-src_prepare() {
-	  kde6_src_prepare
-}
-
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package kde-plasma/kglobalacceld-6.5.5-r1 for branch mark-31 by mark-bot