### PR TITLE
mark-devkit: [mark-iii] Bump kde-apps/kaccounts-providers-25.12.2-r1

### DIFF
--- a/kde-apps/kaccounts-providers/kaccounts-providers-25.12.2-r1.ebuild
+++ b/kde-apps/kaccounts-providers/kaccounts-providers-25.12.2-r1.ebuild
@@ -11,7 +11,7 @@ SLOT="6"
 KEYWORDS="*"
 RDEPEND="virtual/kde-seed[gui,declarative]
 	dev-qt/qtwebengine:6[qml]
-	>=net-libs/signon-oauth2-0.25
+	>=net-libs/signon-oauth2-0.25_p20210102[qt6(+)]
 	>=net-libs/signon-ui-0.15_p20231016
 	kde-apps/kaccounts-integration:6
 	kde-frameworks/kcoreaddons:6


### PR DESCRIPTION
Automatic bump of package kde-apps/kaccounts-providers-25.12.2-r1 for branch mark-iii by mark-bot