### PR TITLE
mark-devkit: [mark-iii] Bump kde-apps/signon-kwallet-extension-25.12.2-r1

### DIFF
--- a/kde-apps/signon-kwallet-extension/signon-kwallet-extension-25.12.2-r1.ebuild
+++ b/kde-apps/signon-kwallet-extension/signon-kwallet-extension-25.12.2-r1.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://download.kde.org/stable/release-service/25.12.2/src/signon-kwal
 SLOT="6"
 KEYWORDS="*"
 RDEPEND="kde-frameworks/kwallet:6
-	>=net-libs/signond-8.61
+	>=net-libs/signond-8.61-r100[qt6(+)]
 	
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Automatic bump of package kde-apps/signon-kwallet-extension-25.12.2-r1 for branch mark-iii by mark-bot