### PR TITLE
mark-devkit: [mark-31] Bump kde-apps/kmix-25.12.2-r1

### DIFF
--- a/kde-apps/kmix/kmix-25.12.2-r1.ebuild
+++ b/kde-apps/kmix/kmix-25.12.2-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="virtual/kde-seed[gui]
 	alsa? ( >=media-libs/alsa-lib-1.0.14a )
 	pulseaudio? (
 	  media-libs/libcanberra
-	  media-libs/libpulse
+	  media-sound/pulseaudio
 	)
 	
 "


### PR DESCRIPTION
Automatic bump of package kde-apps/kmix-25.12.2-r1 for branch mark-31 by mark-bot