### PR TITLE
mark-devkit: [mark-31] Bump kde-apps/kwave-25.12.2-r1

### DIFF
--- a/kde-apps/kwave/kwave-25.12.2-r1.ebuild
+++ b/kde-apps/kwave/kwave-25.12.2-r1.ebuild
@@ -44,7 +44,7 @@ RDEPEND="virtual/kde-seed[gui,multimedia?]
 	  media-libs/libogg
 	  media-libs/opus
 	)
-	pulseaudio? ( media-libs/libpulse )
+	pulseaudio? ( media-sound/pulseaudio )
 	vorbis? (
 	  media-libs/libogg
 	  media-libs/libvorbis


### PR DESCRIPTION
Automatic bump of package kde-apps/kwave-25.12.2-r1 for branch mark-31 by mark-bot