### PR TITLE
mark-devkit: [mark-iii] Bump x11-misc/pcmanfm-qt-2.3.0-r1

### DIFF
--- a/x11-misc/pcmanfm-qt/pcmanfm-qt-2.3.0-r1.ebuild
+++ b/x11-misc/pcmanfm-qt/pcmanfm-qt-2.3.0-r1.ebuild
@@ -31,6 +31,9 @@ post_src_unpack() {
 	mv lxqt-pcmanfm-qt-* ${S}
 }
 
+src_prepare() {
+	cmake_src_prepare
+}
 
 pkg_postinst() {
 	  xdg_desktop_database_update


### PR DESCRIPTION
Automatic bump of package x11-misc/pcmanfm-qt-2.3.0-r1 for branch mark-iii by mark-bot