### PR TITLE
mark-devkit: [mark-iii] Bump x11-libs/libfm-qt-2.3.1-r1

### DIFF
--- a/x11-libs/libfm-qt/libfm-qt-2.3.1-r1.ebuild
+++ b/x11-libs/libfm-qt/libfm-qt-2.3.1-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit cmake xdg
+inherit cmake
 
 DESCRIPTION="Core library of PCManFM-Qt (Qt binding for libfm)"
 HOMEPAGE="https://lxqt-project.org"


### PR DESCRIPTION
Automatic bump of package x11-libs/libfm-qt-2.3.1-r1 for branch mark-iii by mark-bot