### PR TITLE
mark-devkit: [mark-iii] Bump kde-apps/partitionmanager-25.12.2-r1

### DIFF
--- a/kde-apps/partitionmanager/partitionmanager-25.12.2-r1.ebuild
+++ b/kde-apps/partitionmanager/partitionmanager-25.12.2-r1.ebuild
@@ -2,7 +2,7 @@
 # Autogen by MARK Devkit
 
 EAPI=7
-inherit xdg kde6
+inherit kde6 xdg
 
 DESCRIPTION="Utility for management of disks, partitions and file systems"
 HOMEPAGE="https://apps.kde.org/partitionmanager/"


### PR DESCRIPTION
Automatic bump of package kde-apps/partitionmanager-25.12.2-r1 for branch mark-iii by mark-bot